### PR TITLE
modify the extension activation rule

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "homepage": "https://github.com/milannankov/vscode-ui5/blob/master/README.md",
     "main": "./out/extension",
     "activationEvents": [
-        "workspaceContains:**/manifest.json"
+        "*"
     ],
     "contributes": {
         "configuration": {


### PR DESCRIPTION
Hi ,

https://github.com/milannankov/vscode-ui5/issues/2
I created ui5 project from scratch, which doesn't contain manifest.json file, so the extension doesn't work, I don't think manifset.json should mandatory to activate vscode-ui5 extension. This commit could solve the above.

Thanks
